### PR TITLE
fix: Backup of PGSQL databases without SPLIT_DB

### DIFF
--- a/install/etc/s6/services/10-db-backup/run
+++ b/install/etc/s6/services/10-db-backup/run
@@ -157,7 +157,7 @@ function backup_pgsql() {
             done
         else
             export PGPASSWORD=${DBPASS}
-            pg_dump -h ${DBHOST} -U ${DBUSER} $db > ${TMPDIR}/${TARGET}
+            pg_dump -h ${DBHOST} -U ${DBUSER} ${DBNAME} > ${TMPDIR}/${TARGET}
             generate_md5
             compression
             move_backup


### PR DESCRIPTION
Hello tiredofit, thanks again for your work it is helpful!

I am not sure how this works but I also do not understand how the variable $db is set.
So I propose this change which helped my PostgreSQL backup to complete.