### PR TITLE
Fix influx args as well as some errors in the log

### DIFF
--- a/install/etc/s6/services/10-db-backup/run
+++ b/install/etc/s6/services/10-db-backup/run
@@ -126,7 +126,7 @@ function backup_mysql() {
 
 function backup_influx() {
     for DB in $DB_NAME; do
-        influxd backup -database $DB -host ${DBHOST} -p ${DBPORT} ${TMPDIR}/${TARGET}
+        influxd backup -database $DB -host ${DBHOST}:${DBPORT} ${TMPDIR}/${TARGET}
         generate_md5
         compression
         move_backup

--- a/install/etc/s6/services/10-db-backup/run
+++ b/install/etc/s6/services/10-db-backup/run
@@ -2,7 +2,7 @@
 
 date >/dev/null
 
-if [ $1 != "NOW" ]; then
+if [ "$1" != "NOW" ]; then
     sleep 10
 fi
 
@@ -37,7 +37,7 @@ MD5=${MD5:-TRUE}
 SPLIT_DB=${SPLIT_DB:-FALSE}
 TMPDIR=/tmp/backups
 
-if [ $1 = "NOW" ]; then
+if [ "$1" = "NOW" ]; then
     DB_DUMP_BEGIN=+0
     MANUAL=TRUE
 fi


### PR DESCRIPTION
Whenever I run the backup I see these two lines at the top of my log:
```
./run: line 5: [: !=: unary operator expected
./run: line 40: [: =: unary operator expected
```
I fixed this by wrapping the variables in quotes (as seen here: https://stackoverflow.com/questions/408975/compare-integer-in-bash-unary-operator-expected)

I also mentioned adding the port argument to influx in another issue (#5) and the fix that was applied is actually wrong.. I guess this verison of the influx cli takes the port as part of the `-host` argument. To keep the software config the same between database types I just made it append the port to the host in the `-host` argument.

This should fix influx backup and remove those two errors from the log.