### PR TITLE
Fix couchdb backup endpoint; Set ENABLE_ZABBIX to FALSE by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ COPY --from=mongo-packages / /usr/src/apk
 
 ### Set Environment Variables
    ENV ENABLE_CRON=FALSE \
-       ENABLE_SMTP=FALSE
+       ENABLE_SMTP=FALSE \
+       ENABLE_ZABBIX=FALSE
 
 ### Dependencies
    RUN set -ex && \

--- a/install/etc/s6/services/10-db-backup/run
+++ b/install/etc/s6/services/10-db-backup/run
@@ -97,7 +97,7 @@ fi
 ### Functions
 function backup_couch() {
     TARGET=couch_${DBNAME}_${DBHOST}_${now}.txt
-    curl -X GET http://${DBHOST}:${DBPORT}/${DBNAME}/ all docs? include docs=true >${TMPDIR}/${TARGET}
+    curl -X GET http://${DBHOST}:${DBPORT}/${DBNAME}/_all_docs?include_docs=true >${TMPDIR}/${TARGET}
     generate_md5
     compression
     move_backup


### PR DESCRIPTION
- The couchdb backup endpoint was wrong (missing underscores in URL)
- The ENABLE_ZABBIX was set to TRUE from the base image, which will cause some errors get logged (not a big deal)