### PR TITLE
information_schema.FILES is always empty for mariadb > 10.2

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -294,8 +294,7 @@ check_availability() {
             COUNTER=0
             while true; do
                 mysqlcmd='mysql -u'${dbuser}' -P '${dbport}' -h '${dbhost}' -p'${dbpass}
-                out="$($mysqlcmd -e "SELECT COUNT(*) FROM information_schema.FILES;" 2>&1)"
-                echo "$out" | grep -E "COUNT|Enter" 2>&1 > /dev/null
+                out=$($mysqlcmd -e "SHOW STATUS;")
                 if [ $? -eq 0 ]; then
                     :
                     break


### PR DESCRIPTION
see below link, this will cause the mariadb check_availability always failed
https://mariadb.com/kb/en/information_schemafiles-is-empty-in-mariadb-102/