### PR TITLE
#81 Backup to S3 got error: No module named 'six'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN set -ex && \
                bzip2-dev \
                git \
                libarchive-dev \
-               py3-pip \
                xz-dev \
                && \
     \
@@ -31,6 +30,7 @@ RUN set -ex && \
                postgresql \
                postgresql-client \
                python3 \
+               py3-pip \
                redis \
                sqlite \
                xz \


### PR DESCRIPTION
In Dockerfile the command `apk del .db-backup-build-deps` has deleted the python package `py-pip`