### PR TITLE
fix: not able to connect to mysql 8 db with caching_sha2_password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ RUN set -ex && \
                influxdb \
                libarchive \
                mariadb-client \
+               mariadb-connector-c \
                mongodb-tools \
                libressl \
                pigz \


### PR DESCRIPTION
Install `mariadb-connector-c` which contains the `caching_sha2_password` plugin and allows connecting to mysql 8 databases that use default authentication.