### PR TITLE
Fix compression on Redis backup

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -243,8 +243,10 @@ backup_redis() {
         print_info "Redis Busy - Waiting and retrying in 5 seconds"
         sleep 5
     done
-    generate_md5
+    target_original=${target}
     compression
+    $dumpoutput "${tmpdir}/${target_original}"
+    generate_md5
     move_backup
 }
 


### PR DESCRIPTION
- Jump out the loop when backup is completed [4488d11](4488d11)
- Fix compression issue [4e41e66](4e41e66)
  - Move MD5 to be calculated after compression
  - Add temporary `$target_original` for using after `compression` function replace `$target` value

-- update
Issue reference #58 