### PR TITLE
MINIO support by reacting to S3_HOST

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -420,7 +420,10 @@ move_backup() {
             export AWS_ACCESS_KEY_ID=${S3_KEY_ID}
             export AWS_SECRET_ACCESS_KEY=${S3_KEY_SECRET}
             export AWS_DEFAULT_REGION=ap-northeast-2
-            aws s3 cp ${tmpdir}/${target} s3://${S3_BUCKET}/${S3_PATH}/${target}
+
+            [[ ( -n "${S3_HOST}" ) ]] && PARAM_AWS_ENDPOINT_URL=" --endpoint-url ${S3_PROTOCOL}://${S3_HOST}"
+
+            aws ${PARAM_AWS_ENDPOINT_URL} s3 cp ${tmpdir}/${target} s3://${S3_BUCKET}/${S3_PATH}/${target}
 
             rm -rf ${tmpdir}/*.md5
             rm -rf ${tmpdir}/"${target}"


### PR DESCRIPTION
The proper way to use MINIO or other S3-compatible object stores is by using the `--endpoint-url` parameter on the `aws` CLI.

All the configuration was well defined and prepared, but the `S3_HOST` environment variable was not used and thus MINIO users were not able to use this container. With this PR, that should be addressed.

I am myself a MINIO user and, after the proposed modifications, I was able to use this.