### PR TITLE
Fixing the print_notice for Next Backup when `DB_DUMP_BEGIN` is +XXX

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -438,9 +438,10 @@ print_debug "Backup routines Initialized on $(date)"
     today=$(date +"%Y%m%d")
 
     if [[ $DB_DUMP_BEGIN =~ ^\+(.*)$ ]]; then
-            waittime=$(( ${BASH_REMATCH[1]} * 60 ))
+        waittime=$(( ${BASH_REMATCH[1]} * 60 ))
+        target_time=$(($current_time + $waittime))
     else
-            target_time=$(date --date="${today}${DB_DUMP_BEGIN}" +"%s")
+        target_time=$(date --date="${today}${DB_DUMP_BEGIN}" +"%s")
         if [[ "$target_time" < "$current_time" ]]; then
             target_time=$(($target_time + 24*60*60))
         fi


### PR DESCRIPTION
The variable `target_time` was not being set when `DB_DUMP_BEGIN` was a relative time (i.e., it is a +XXX value).

Everything was working, but there was an ugly log message

```
2021-12-13-20:46:28 [NOTICE] ** [db-backup] Next Backup at                                                                              
date: invalid date '@'                                                                                                                  
```

The solution was to simply set the `target_time` variable in that branch of the if.