### PR TITLE
Use exit code 0 when running in manual mode

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -529,7 +529,7 @@ print_debug "Backup routines Initialized on $(date)"
 
     ### Go back to Sleep until next Backup time
     if var_true $MANUAL ; then
-        exit 1;
+        exit 0;
     else
         sleep $(($DB_DUMP_FREQ*60))
     fi


### PR DESCRIPTION
Hi,
thanks for this really nice and comprehensive project!

When running this container as a Kubernetes cronjob, it is really inconvenient that the script exits with return code "1", thereby marking the job as a failure.
Instead, the script should return "0" because everything was successful.