### PR TITLE
Correct several variables for S3 backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ If `BACKUP_LOCATION` = `S3` then the following options are used.
 
 | Parameter       | Description                                                                             |
 | --------------- | --------------------------------------------------------------------------------------- |
-| `S3_BUCKET`     | S3 Bucket name e.g. 'mybucket'                                                          |
-| `S3_HOST`       | Hostname of S3 Server e.g "s3.amazonaws.com" - You can also include a port if necessary |
+| `S3_BUCKET`     | S3 Bucket name e.g. `mybucket`                                                          |
+| `S3_ENDPOINT`   | URL of S3-compatible endpoint, e.g. `http://minio:8080`                                 |
 | `S3_KEY_ID`     | S3 Key ID                                                                               |
 | `S3_KEY_SECRET` | S3 Key Secret                                                                           |
 | `S3_PATH`       | S3 Pathname to save to e.g. '`backup`'                                                  |

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -82,13 +82,12 @@ SIZE_VALUE=${SIZE_VALUE:-"bytes"}
 SPLIT_DB=${SPLIT_DB:-"FALSE"}
 TEMP_LOCATION=${TEMP_LOCATION:-"/tmp/backups"}
 
-if [ "$BACKUP_TYPE" = "S3" ] || [ "$BACKUP_TYPE" = "s3" ] || [ "$BACKUP_TYPE" = "MINIO" ] || [ "$BACKUP_TYPE" = "minio" ] ; then
+if [ "$BACKUP_LOCATION" = "S3" ] || [ "$BACKUP_LOCATION" = "s3" ] || [ "$BACKUP_LOCATION" = "MINIO" ] || [ "$BACKUP_LOCATION" = "minio" ] ; then
     S3_PROTOCOL=${S3_PROTOCOL:-"https"}
-    sanity_var S3_HOST "S3 Host"
+    sanity_var S3_ENDPOINT "S3 Endpoint URL"
     sanity_var S3_BUCKET "S3 Bucket"
     sanity_var S3_KEY_ID "S3 Key ID"
     sanity_var S3_KEY_SECRET "S3 Key Secret"
-    sanity_var S3_URI_STYLE "S3 URI Style (Virtualhost or Path)"
     sanity_var S3_PATH "S3 Path"
     sanity_var S3_REGION "S3 Region"
     file_env 'S3_KEY_ID'


### PR DESCRIPTION
Hi,
thanks again for this nice project.

While setting up backups in my environment I struggled with several inconsistencies and thought I would address them in this PR.

* S3_URI_STYLE is not used anywhere (anymore)
* BACKUP_TYPE is not documented anywhere, redundant with BACKUP_LOCATION
* S3_HOST is not used anymore, document S3_ENDPOINT instead

ref https://github.com/tiredofit/docker-db-backup/commit/4d6419fd184590c3620a7a9a5e70ef3adecb97ee