### PR TITLE
Fix S3 variables (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ If `BACKUP_LOCATION` = `S3` then the following options are used.
 | Parameter       | Description                                                                             |
 | --------------- | --------------------------------------------------------------------------------------- |
 | `S3_BUCKET`     | S3 Bucket name e.g. `mybucket`                                                          |
-| `S3_ENDPOINT`   | URL of S3-compatible endpoint, e.g. `http://minio:8080`                                 |
 | `S3_KEY_ID`     | S3 Key ID                                                                               |
 | `S3_KEY_SECRET` | S3 Key Secret                                                                           |
 | `S3_PATH`       | S3 Pathname to save to e.g. '`backup`'                                                  |
-| `S3_PROTOCOL`   | Use either `http` or `https` to access service - Default `https`                        |
 | `S3_REGION`     | Define region in which bucket is defined. Example: `ap-northeast-2`                     |
+| `S3_HOST`       | Hostname (and port) of S3-compatible service, e.g. `minio:8080`. Defaults to AWS.       |
+| `S3_PROTOCOL`   | Protocol to connect to `S3_HOST`. Either `http` or `https`. Defaults to `https`.        |
 
 
 ## Maintenance

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -84,7 +84,6 @@ TEMP_LOCATION=${TEMP_LOCATION:-"/tmp/backups"}
 
 if [ "$BACKUP_LOCATION" = "S3" ] || [ "$BACKUP_LOCATION" = "s3" ] || [ "$BACKUP_LOCATION" = "MINIO" ] || [ "$BACKUP_LOCATION" = "minio" ] ; then
     S3_PROTOCOL=${S3_PROTOCOL:-"https"}
-    sanity_var S3_ENDPOINT "S3 Endpoint URL"
     sanity_var S3_BUCKET "S3 Bucket"
     sanity_var S3_KEY_ID "S3 Key ID"
     sanity_var S3_KEY_SECRET "S3 Key Secret"


### PR DESCRIPTION
Hi, it's me again!
I wanted to update to the latest tag today, but it turns out that I actually messed up my last PR - sorry about that.
S3_ENDPOINT is not used anywhere in the code, but S3_HOST.

Fixes https://github.com/tiredofit/docker-db-backup/issues/89