### PR TITLE
Unary operator fix

### DIFF
--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -446,7 +446,7 @@ cleanup_old_data() {
                         s3_olderthan=$(echo $(( $(date +%s)-${DB_CLEANUP_TIME}*60 )))
                         if [[ $s3_createdate -le $s3_olderthan ]] ; then
                             s3_filename=$(echo $s3_file | awk {'print $4'})
-                            if [ $s3_filename != "" ] ; then
+                            if [ "$s3_filename" != "" ] ; then
                                 print_debug "Deleting $s3_filename"
                                 silent aws ${PARAM_AWS_ENDPOINT_URL} s3 rm s3://${S3_BUCKET}/${S3_PATH}/${s3_filename} ${s3_ssl} ${s3_ca_cert} ${S3_EXTRA_OPTS}
                             fi


### PR DESCRIPTION
When running backup-now got error in log:
`
date: invalid date 'PRE pritunl.x-coding.pl/'
/assets/functions/10-db-backup: line 449: [: !=: unary operator expected
`
Not sure from where got 1st one, but 2nd is fixed by that.