### PR TITLE
Fix reading port number in interactive restore

### DIFF
--- a/install/usr/local/bin/restore
+++ b/install/usr/local/bin/restore
@@ -641,7 +641,7 @@ EOF
         2 )
             while true; do
                 read -p "$(echo -e ${clg}** ${cdgy}Enter Value \(${cwh}C${cdgy}\) \| \(${cwh}E${cdgy}\)  : ${cwh}${coff}) " q_dbport_menu
-                case "${q_port_menu,,}" in
+                case "${q_dbport_menu,,}" in
                     c* )
                         counter=1
                         q_dbport=" "


### PR DESCRIPTION
Fixes the variable name used to check which option was selected during port selection in interactive restore. Since the variable was empty, the port was not read from any source (environment variable or interactive input).

I looked a little further in the version history and, as far as I can see, the 3.3.5 update introduced the issue, even though the changelog claims to actually fix the issue : https://github.com/tiredofit/docker-db-backup/compare/3.3.4...3.3.5, so maybe I'm just missing something and this PR isn't actually needed.