### PR TITLE
Add --rsyncable for gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Your Organization will be mapped to `DB_USER` and your root token will need to b
 | `COMPRESSION_LEVEL`            | Numberical value of what level of compression to use, most allow `1` to `9` except for `ZSTD` which allows for `1` to `19` - | `3`            |
 | `ENABLE_PARALLEL_COMPRESSION`  | Use multiple cores when compressing backups `TRUE` or `FALSE`                                                                | `TRUE`         |
 | `PARALLEL_COMPRESSION_THREADS` | Maximum amount of threads to use when compressing - Integer value e.g. `8`                                                   | `autodetected` |
+| `GZ_RSYNCABLE` | Use --rsyncable (gzip only) for faster rsync transfers and incremental backup deduplication. e.g. `TRUE`                                                   | `FALSE` |
 | `ENABLE_CHECKSUM`              | Generate either a MD5 or SHA1 in Directory, `TRUE` or `FALSE`                                                                | `TRUE`         |
 | `CHECKSUM`                     | Either `MD5` or `SHA1`                                                                                                       | `MD5`          |
 | `EXTRA_OPTS`                   | If you need to pass extra arguments to the backup command, add them here e.g. `--extra-command`                              |                |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Your Organization will be mapped to `DB_USER` and your root token will need to b
 | `COMPRESSION_LEVEL`            | Numberical value of what level of compression to use, most allow `1` to `9` except for `ZSTD` which allows for `1` to `19` - | `3`            |
 | `ENABLE_PARALLEL_COMPRESSION`  | Use multiple cores when compressing backups `TRUE` or `FALSE`                                                                | `TRUE`         |
 | `PARALLEL_COMPRESSION_THREADS` | Maximum amount of threads to use when compressing - Integer value e.g. `8`                                                   | `autodetected` |
-| `GZ_RSYNCABLE` | Use --rsyncable (gzip only) for faster rsync transfers and incremental backup deduplication. e.g. `TRUE`                                                   | `FALSE` |
+| `GZ_RSYNCABLE`                 | Use `--rsyncable` (gzip only) for faster rsync transfers and incremental backup deduplication. e.g. `TRUE`                   | `FALSE`        |
 | `ENABLE_CHECKSUM`              | Generate either a MD5 or SHA1 in Directory, `TRUE` or `FALSE`                                                                | `TRUE`         |
 | `CHECKSUM`                     | Either `MD5` or `SHA1`                                                                                                       | `MD5`          |
 | `EXTRA_OPTS`                   | If you need to pass extra arguments to the backup command, add them here e.g. `--extra-command`                              |                |

--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -468,7 +468,10 @@ compression() {
 
    case "${COMPRESSION,,}" in
         gz* )
-            compress_cmd="pigz -q -${COMPRESSION_LEVEL} -p ${PARALLEL_COMPRESSION_THREADS} "
+            if var_true "${GZ_RSYNCABLE}" ; then
+                gz_rsyncable=--rsyncable
+            fi
+            compress_cmd="pigz -q -${COMPRESSION_LEVEL} -p ${PARALLEL_COMPRESSION_THREADS} ${gz_rsyncable}"
             compression_type="gzip"
             extension=".gz"
             dir_compress_cmd=${compress_cmd}


### PR DESCRIPTION
This adds the option `GZ_RSYNCABLE` for gzip compression. Rsync and Duplicati transfers/backupss of large archives are much faster when this option is used. 