### PR TITLE
Update Dockerfile to use influxdb client 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Dave Conroy (github.com/tiredofit)"
 
 ### Set Environment Variables
 
-ENV INFLUX2_VERSION=2.2.1 \
+ENV INFLUX2_VERSION=2.4.0 \
     MSSQL_VERSION=18.0.1.1-1 \
     CONTAINER_ENABLE_MESSAGING=FALSE \
     CONTAINER_ENABLE_MONITORING=TRUE \


### PR DESCRIPTION
Update influxdb client to 2.4.0.

Scanning the current latest image of db-backup shows a number of CVEs associated with the installed 2.2.1 version of /usr/sbin/influx. PR updates the client to the latest 2.4.0. 

```
usr/sbin/influx (gobinary)

Total: 5 (MEDIUM: 1, HIGH: 4, CRITICAL: 0)

┌─────────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                            Title                            │
├─────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2020-29652 │ HIGH     │ v0.0.0-20200622213623-75b288015ac9 │ 0.0.0-20201216223049-8b5274cf687f │ golang: crypto/ssh: crafted authentication request can lead │
│                     │                │          │                                    │                                   │ to nil pointer dereference                                  │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2020-29652                  │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                     │ CVE-2021-43565 │          │                                    │ 0.0.0-20211202192323-5770296d904e │ golang.org/x/crypto: empty plaintext packet causes panic    │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-43565                  │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                     │ CVE-2022-27191 │          │                                    │ 0.0.0-20220314234659-1baeb1ce4c0b │ golang: crash in a golang.org/x/crypto/ssh server           │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                  │
├─────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/sys    │ CVE-2022-29526 │ MEDIUM   │ v0.0.0-20210831042530-f4d43177bf5e │ 0.0.0-20220412211240-33da011f77ad │ golang: syscall: faccessat checks wrong group               │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-29526                  │
├─────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/text   │ CVE-2021-38561 │ HIGH     │ v0.3.3                             │ 0.3.7                             │ golang: out-of-bounds read in golang.org/x/text/language    │
│                     │                │          │                                    │                                   │ leads to DoS                                                │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-38561                  │
└─────────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```