### PR TITLE
Fix issue #201 - 99-run_forever exec format error

### DIFF
--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -831,7 +831,6 @@ setup_mode() {
         if var_true "${MANUAL_RUN_FOREVER}" ; then
             mkdir -p /etc/services.d/99-run_forever
             cat <<EOF > /etc/services.d/99-run_forever/run
-
 #!/bin/bash
 while true
 do


### PR DESCRIPTION
This change removes an extra linebreak that causes a non-stop log of errors like this (from #201):

```
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
s6-supervise 99-run_forever: warning: unable to spawn ./run - waiting 10 seconds
s6-supervise 99-run_forever (child): fatal: unable to exec run: Exec format error
```