### PR TITLE
Simplify pg_isready usage

### DIFF
--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -437,8 +437,7 @@ check_availability() {
             ;;
             "pgsql" )
                 counter=0
-                export PGPASSWORD=${DB_PASS}
-                until pg_isready --dbname=${DB_NAME} --host=${DB_HOST} --port=${DB_PORT} --username=${DB_USER} -q
+                until pg_isready --host=${DB_HOST} --port=${DB_PORT} -q
                 do
                     sleep 5
                     (( counter+=5 ))


### PR DESCRIPTION
The [`pg_isready` documentation](https://www.postgresql.org/docs/current/app-pg-isready.html) says that
> It is not necessary to supply correct user name, password, or database name values to obtain the server status; however, if incorrect values are provided, the server will log a failed connection attempt.

E.g.,
```
/ # pg_isready --dbname=thisdbdoesnotexist --host=${DB_HOST} --port=${DB_PORT} --username=thisuserdoesnotexist
postgres: - accepting connections
```

As a result, when we set `DB_NAME` to `ALL`, calls to the `check_availability` function (which uses `pg_isready`) cause the server to log the following error:
```
FATAL:  database "ALL" does not exist
```
To eliminate this error, this change simplifies the `pg_isready` call.