### PR TITLE
#199 Report error when move the backup file to S3 or Blob fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN source /assets/functions/00-container && \
                redis \
                sqlite \
                xz \
+               zip \
                zstd \
                && \
     \

--- a/install/assets/functions/10-db-backup
+++ b/install/assets/functions/10-db-backup
@@ -137,6 +137,7 @@ backup_couch() {
     check_exit_code $target
     generate_checksum
     move_dbbackup
+    check_exit_code "move backup file"
     post_dbbackup ${DB_NAME}
 }
 
@@ -167,6 +168,7 @@ backup_influx() {
                 ltarget=influx_${db}_${DB_HOST#*//}
                 generate_checksum
                 move_dbbackup
+                check_exit_code "move backup file"
                 post_dbbackup $db
             done
         ;;
@@ -187,6 +189,7 @@ backup_influx() {
                 ltarget=influx2_${db}_${DB_HOST#*//}
                 generate_checksum
                 move_dbbackup
+                check_exit_code "move backup file"
                 post_dbbackup $db
             done
         ;;
@@ -216,6 +219,7 @@ backup_mongo() {
     check_exit_code $target
     generate_checksum
     move_dbbackup
+    check_exit_code "move backup file"
     post_dbbackup "${DB_NAME}"
 }
 
@@ -231,6 +235,7 @@ backup_mssql() {
     check_exit_code $target
     generate_checksum
     move_dbbackup
+    check_exit_code "move backup file"
     post_dbbackup $DB_NAME
 }
 
@@ -271,6 +276,7 @@ backup_mysql() {
                 check_exit_code $target
                 generate_checksum
                 move_dbbackup
+                check_exit_code "move backup file"
                 post_dbbackup $db
         done
     else
@@ -286,6 +292,7 @@ backup_mysql() {
         check_exit_code $target
         generate_checksum
         move_dbbackup
+        check_exit_code "move backup file"
         post_dbbackup all
     fi
 }
@@ -322,6 +329,7 @@ backup_pgsql() {
                 check_exit_code $target
                 generate_checksum
                 move_dbbackup
+                check_exit_code "move backup file"
                 post_dbbackup $db
         done
     else
@@ -345,6 +353,7 @@ backup_pgsql() {
         check_exit_code $target
         generate_checksum
         move_dbbackup
+        check_exit_code "move backup file"
         post_dbbackup all
     fi
 }
@@ -376,6 +385,7 @@ backup_redis() {
     check_exit_code $target
     generate_checksum
     move_dbbackup
+    check_exit_code "move backup file"
     post_dbbackup all
 }
 
@@ -394,6 +404,7 @@ backup_sqlite3() {
     cat "${TEMP_LOCATION}"/backup.sqlite3 | ${dir_compress_cmd} > "${TEMP_LOCATION}/${target}"
     generate_checksum
     move_dbbackup
+    check_exit_code "move backup file"
     post_dbbackup $db
 }
 
@@ -711,6 +722,7 @@ move_dbbackup() {
                 [[ ( -n "${S3_HOST}" ) ]] && PARAM_AWS_ENDPOINT_URL=" --endpoint-url ${S3_PROTOCOL}://${S3_HOST}"
 
                 silent aws ${PARAM_AWS_ENDPOINT_URL} s3 cp ${TEMP_LOCATION}/${target} s3://${S3_BUCKET}/${S3_PATH}/${target} ${s3_ssl} ${s3_ca_cert} ${S3_EXTRA_OPTS}
+                exit_code=$?
                 if var_true "${ENABLE_CHECKSUM}" ; then
                     silent aws ${PARAM_AWS_ENDPOINT_URL} s3 cp ${TEMP_LOCATION}/*.${checksum_extension} s3://${S3_BUCKET}/${S3_PATH}/ ${s3_ssl} ${s3_ca_cert} ${S3_EXTRA_OPTS}
                 fi
@@ -726,6 +738,7 @@ move_dbbackup() {
                 mv "${TEMP_LOCATION}"/"${target}" "${DB_DUMP_TARGET}"/"${target}"
 
                 silent blobxfer upload --mode file --remote-path ${BLOBXFER_REMOTE_PATH} --local-path ${DB_DUMP_TARGET}
+                exit_code=$?
 
                 rm -rf "${TEMP_LOCATION}"/*."${checksum_extension}"
                 rm -rf "${TEMP_LOCATION}"/"${target}"


### PR DESCRIPTION
Capture the exit code of the `aws s3` and `blobxfer` command and reuse `check_exit_code` function to report errors occur in the `move_dbbackup` function. 

<img width="1197" alt="image" src="https://github.com/tiredofit/docker-db-backup/assets/9387800/5164f0fd-b4a4-4588-a6af-c049db3fecfb">

Also add `zip` package to the image to be used in post backup script.