### PR TITLE
Adds a cronjob-like mechanism

### DIFF
--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -33,20 +33,12 @@ else
         waittime=$(($target_time - $current_time))
     elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})[[:space:]]([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]];
     then
-        # Extract year, month, day, hours, minutes, and seconds from DB_DUMP_BEGIN
-        db_year=${BASH_REMATCH[1]}
-        db_month=${BASH_REMATCH[2]}
-        db_day=${BASH_REMATCH[3]}
-        db_hour=${BASH_REMATCH[4]}
-        db_minute=${BASH_REMATCH[5]}
-        db_second=${BASH_REMATCH[6]}
-
         # Calculate DB_DUMP_BEGIN time in seconds
-        db_time=$(date -d "${db_year}-${db_month}-${db_day} ${db_hour}:${db_minute}:${db_second}" +%s)
-        print_debug "DB time = $db_time"
+        dump_time=$(date -d "${DB_DUMP_BEGIN}" +%s)
+        print_debug "Dump time = $dump_time"
 
         # Calculate the difference in seconds
-        waittime=$((db_time - current_time))
+        waittime=$((dump_time - current_time))
         print_debug "Difference in seconds: $waittime"
 
         if (( $waittime < 0 )); then
@@ -58,7 +50,7 @@ else
         target_time=$(($current_time + $waittime))
         print_debug "Target time = $target_time"
     else
-        print_info "DB_DUMP_BEGIN is not starting with + or is not an integer or is not in the correct format (hh:mm:ss)."
+        print_info "DB_DUMP_BEGIN is not starting with + or is not an integer or is not in the correct format (YYYY-mm-dd hh:mm:ss)."
     fi
 
     print_debug "******** End DB_DUMP_BEGIN ********"

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -25,8 +25,12 @@ else
         target_time=$(($current_time + $waittime))
     elif [[ $DB_DUMP_BEGIN =~ ^[0-9]+$ ]]; then
         print_debug "DB_DUMP_BEGIN is an integer."
-        waittime=$(( ${BASH_REMATCH[1]} * 60 ))
-        target_time=$(($current_time + $waittime))
+        
+        target_time=$(date --date="${today}${DB_DUMP_BEGIN}" +"%s")
+        if [[ "$target_time" < "$current_time" ]]; then
+            target_time=$(($target_time + 24*60*60))
+        fi
+        waittime=$(($target_time - $current_time))
     elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})[[:space:]]([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]];
     then
         # Extract year, month, day, hours, minutes, and seconds from DB_DUMP_BEGIN

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -16,17 +16,37 @@ else
     current_time=$(date +"%s")
     today=$(date +"%Y%m%d")
 
-    if [[ $DB_DUMP_BEGIN =~ ^\+(.*)$ ]]; then
+    # Check if DB_DUMP_BEGIN is an integer
+    if [[ $DB_DUMP_BEGIN =~ ^[0-9]+$ ]]; then
+        print_info "DB_DUMP_BEGIN is an integer."
         waittime=$(( ${BASH_REMATCH[1]} * 60 ))
         target_time=$(($current_time + $waittime))
-    else
-        target_time=$(date --date="${today}${DB_DUMP_BEGIN}" +"%s")
-        if [[ "$target_time" < "$current_time" ]]; then
-            target_time=$(($target_time + 24*60*60))
+    elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]]; then
+        print_info "DB_DUMP_BEGIN is time."
+        # Extract hours, minutes, and seconds from DB_DUMP_BEGIN
+        db_hour=${BASH_REMATCH[1]}
+        db_minute=${BASH_REMATCH[2]}
+        db_second=${BASH_REMATCH[3]}
+
+        # Calculate DB_DUMP_BEGIN time in seconds
+        db_time=$(date -d "${db_hour}:${db_minute}:${db_second}" +%s)
+
+        # Calculate the difference in seconds
+        waittime=$((db_time - current_time))
+        print_info "Difference in seconds: $waittime"
+
+        if (( $waittime < 0 )); then
+            waittime=$(( ($waittime + ($DB_DUMP_FREQ - 1)) / ($DB_DUMP_FREQ * 60) ))
+            waittime=$(( $waittime * -1 ))
+            print_info "Difference in seconds (rounded): $waittime"
         fi
-        waittime=$(($target_time - $current_time))
+
+        target_time=$(($current_time + $waittime))
+    else
+        print_info "DB_DUMP_BEGIN is not an integer or in the correct format (hh:mm:ss)."
     fi
-    print_debug "Wait Time: ${waittime} Target time: ${target_time} Current Time: ${current_time}"
+
+    print_info "Wait Time: ${waittime} Target time: $(date -d @${target_time} +"%Y-%m-%d %T %Z") Current Time: $(date -d @${current_time} +"%Y-%m-%d %T %Z")"
     print_info "Next Backup at $(date -d @${target_time} +"%Y-%m-%d %T %Z")"
     sleep $waittime
 fi

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -16,13 +16,19 @@ else
     current_time=$(date +"%s")
     today=$(date +"%Y%m%d")
 
-    # Check if DB_DUMP_BEGIN is an integer
-    if [[ $DB_DUMP_BEGIN =~ ^[0-9]+$ ]]; then
-        print_info "DB_DUMP_BEGIN is an integer."
+    print_debug "******** Begin DB_DUMP_BEGIN ********"
+    print_debug "Current time $current_time"
+
+    if [[ $DB_DUMP_BEGIN =~ ^\+(.*)$ ]]; then
+        print_debug "DB_DUMP_BEGIN is a jump of minute starting with +."
+        waittime=$(( ${BASH_REMATCH[1]} * 60 ))
+        target_time=$(($current_time + $waittime))
+    elif [[ $DB_DUMP_BEGIN =~ ^[0-9]+$ ]]; then
+        print_debug "DB_DUMP_BEGIN is an integer."
         waittime=$(( ${BASH_REMATCH[1]} * 60 ))
         target_time=$(($current_time + $waittime))
     elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]]; then
-        print_info "DB_DUMP_BEGIN is time."
+        print_debug "DB_DUMP_BEGIN is a time."
         # Extract hours, minutes, and seconds from DB_DUMP_BEGIN
         db_hour=${BASH_REMATCH[1]}
         db_minute=${BASH_REMATCH[2]}
@@ -30,24 +36,26 @@ else
 
         # Calculate DB_DUMP_BEGIN time in seconds
         db_time=$(date -d "${db_hour}:${db_minute}:${db_second}" +%s)
+        print_debug "DB time = $db_time"
 
         # Calculate the difference in seconds
         waittime=$((db_time - current_time))
-        print_info "Difference in seconds: $waittime"
+        print_debug "Difference in seconds: $waittime"
 
         if (( $waittime < 0 )); then
             waittime=$(( ($waittime + ($DB_DUMP_FREQ - 1)) / ($DB_DUMP_FREQ * 60) ))
             waittime=$(( $waittime * -1 ))
-            print_info "Difference in seconds (rounded): $waittime"
+            print_debug "Difference in seconds (rounded) waittime is in the past : $waittime"
         fi
 
         target_time=$(($current_time + $waittime))
+        print_debug "Target time = $target_time"
     else
-        print_info "DB_DUMP_BEGIN is not an integer or in the correct format (hh:mm:ss)."
+        print_info "DB_DUMP_BEGIN is not starting with + or is not an integer or is not in the correct format (hh:mm:ss)."
     fi
 
+    print_debug "******** End DB_DUMP_BEGIN ********"
     print_info "Wait Time: ${waittime} Target time: $(date -d @${target_time} +"%Y-%m-%d %T %Z") Current Time: $(date -d @${current_time} +"%Y-%m-%d %T %Z")"
-    print_info "Next Backup at $(date -d @${target_time} +"%Y-%m-%d %T %Z")"
     sleep $waittime
 fi
 

--- a/install/etc/services.available/10-db-backup/run
+++ b/install/etc/services.available/10-db-backup/run
@@ -27,15 +27,18 @@ else
         print_debug "DB_DUMP_BEGIN is an integer."
         waittime=$(( ${BASH_REMATCH[1]} * 60 ))
         target_time=$(($current_time + $waittime))
-    elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]]; then
-        print_debug "DB_DUMP_BEGIN is a time."
-        # Extract hours, minutes, and seconds from DB_DUMP_BEGIN
-        db_hour=${BASH_REMATCH[1]}
-        db_minute=${BASH_REMATCH[2]}
-        db_second=${BASH_REMATCH[3]}
+    elif [[ $DB_DUMP_BEGIN =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})[[:space:]]([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]];
+    then
+        # Extract year, month, day, hours, minutes, and seconds from DB_DUMP_BEGIN
+        db_year=${BASH_REMATCH[1]}
+        db_month=${BASH_REMATCH[2]}
+        db_day=${BASH_REMATCH[3]}
+        db_hour=${BASH_REMATCH[4]}
+        db_minute=${BASH_REMATCH[5]}
+        db_second=${BASH_REMATCH[6]}
 
         # Calculate DB_DUMP_BEGIN time in seconds
-        db_time=$(date -d "${db_hour}:${db_minute}:${db_second}" +%s)
+        db_time=$(date -d "${db_year}-${db_month}-${db_day} ${db_hour}:${db_minute}:${db_second}" +%s)
         print_debug "DB time = $db_time"
 
         # Calculate the difference in seconds


### PR DESCRIPTION
Based on the issue #214 I propose a solution to use DB_DUMP_BEGIN as a base time to run like a cronjob.

If the DB_DUMP_BEGIN is specified in hh:mm:ss format, then the system uses it as a base time with DB_DUMP_FREQ as the recursion.

I'm open to comments about this solutions.