### PR TITLE
Sort filenames alphabetically when using the restore command

### DIFF
--- a/install/usr/local/bin/restore
+++ b/install/usr/local/bin/restore
@@ -78,7 +78,7 @@ fi
 get_filename() {
     COLUMNS=12
     prompt="Please select a file to restore:"
-    options=( $(find "${DB_DUMP_TARGET}" -type f -maxdepth 1  -not -name '*.md5' -not -name '*.sha1' -print0 | xargs -0) )
+    options=( $(find "${DB_DUMP_TARGET}" -type f -maxdepth 1  -not -name '*.md5' -not -name '*.sha1' -print0 | sort -z | xargs -0) )
     PS3="$prompt "
     select opt in "${options[@]}" "Custom" "Quit" ; do
         if (( REPLY == 2 + ${#options[@]} )) ; then


### PR DESCRIPTION
Fix https://github.com/tiredofit/docker-db-backup/issues/136

The filenames display by the `restore` command are not sorted
```
...
279) /backups/today/mongo_my_project_mongo_20231010-223817.archive.gz
280) /backups/today/mongo_my_project_mongo_20231011-052321.archive.gz
281) /backups/today/mongo_my_project_mongo_20231010-231817.archive.gz
282) /backups/today/mongo_my_project_mongo_20231011-084822.archive.gz
283) /backups/today/mongo_my_project_mongo_20231010-224817.archive.gz
284) /backups/today/mongo_my_project_mongo_20231011-190827.archive.gz
285) /backups/today/mongo_my_project_mongo_20231011-060821.archive.gz
286) /backups/today/mongo_my_project_mongo_20231010-220817.archive.gz
287) /backups/today/mongo_my_project_mongo_20231011-061321.archive.gz
288) /backups/today/mongo_my_project_mongo_20231010-192316.archive.gz
289) /backups/today/mongo_my_project_mongo_20231011-074822.archive.gz
```

And with `| sort -z` it is:

```
...
279) /backups/today/mongo_my_project_mongo_20231011-181326.archive.gz
280) /backups/today/mongo_my_project_mongo_20231011-181826.archive.gz
281) /backups/today/mongo_my_project_mongo_20231011-182326.archive.gz
282) /backups/today/mongo_my_project_mongo_20231011-182826.archive.gz
283) /backups/today/mongo_my_project_mongo_20231011-183326.archive.gz
284) /backups/today/mongo_my_project_mongo_20231011-183827.archive.gz
285) /backups/today/mongo_my_project_mongo_20231011-184326.archive.gz
286) /backups/today/mongo_my_project_mongo_20231011-184826.archive.gz
287) /backups/today/mongo_my_project_mongo_20231011-185326.archive.gz
288) /backups/today/mongo_my_project_mongo_20231011-185826.archive.gz
289) /backups/today/mongo_my_project_mongo_20231011-190326.archive.gz
```

-z option documentation:
```
 -z, --zero-terminated
             Use NUL as record separator.  By default, records in the files are supposed to be separated by the newline characters.
             With this option, NUL (´\0´) is used as a record separator character.
```
Used because we use `-print0`
