### PR TITLE
Use authentification database in mongorestore

### DIFF
--- a/install/usr/local/bin/restore
+++ b/install/usr/local/bin/restore
@@ -925,7 +925,10 @@ case "${r_dbtype}" in
         if [ -n "${r_dbpass}" ] ; then
             mongo_pass="-p=${r_dbpass}"
         fi
-        mongorestore ${mongo_compression} -d=${r_dbname} -h=${r_dbhost} --port=${r_dbport} ${mongo_user} ${mongo_pass} --archive=${r_filename}
+        if [ -n "${DB_AUTH}" ] ; then
+            mongo_auth_database="--authenticationDatabase=${DB_AUTH}"
+        fi
+        mongorestore ${mongo_compression} -d=${r_dbname} -h=${r_dbhost} --port=${r_dbport} ${mongo_user} ${mongo_pass} --archive=${r_filename} ${mongo_auth_database}
         exit_code=$?
     ;;
     * )


### PR DESCRIPTION
This should fix https://github.com/tiredofit/docker-db-backup/issues/112

When an authentication database is specified in `DB_AUTH`, it's used for the backup but not for the restore.

From the [mongorestore documentation](https://www.mongodb.com/docs/database-tools/mongorestore/#std-option-mongorestore.--authenticationDatabase):

> --authenticationDatabase=<dbname>
> Specifies the authentication database where the specified --username has been created.

Without this option, when the user is in the `admin` authentication database, this error occurs:

```
2023-10-11T23:02:59.017+0200 error connecting to host: could not connect to server: connection() error occurred during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.
2023-10-11.23:02:59 [ERROR] ** [db-backup-restore] Restore reported errors
```