### PR TITLE
#298 Use pip to install awscli to remove the deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV INFLUX_VERSION=1.8.0 \
     INFLUX2_VERSION=2.4.0 \
     MSODBC_VERSION=18.3.2.1-1 \
     MSSQL_VERSION=18.3.1.1-1 \
-    AWS_CLI_VERSION=1.31.4 \
+    AWS_CLI_VERSION=1.31.5 \
     CONTAINER_ENABLE_MESSAGING=FALSE \
     CONTAINER_ENABLE_MONITORING=TRUE \
     CONTAINER_PROCESS_RUNAWAY_PROTECTOR=FALSE \
@@ -73,8 +73,7 @@ RUN source /assets/functions/00-container && \
     \
     if [ $mssql = "true" ] ; then curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_${MSODBC_VERSION}_${mssql_arch}.apk ; curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/mssql-tools18_${MSSQL_VERSION}_${mssql_arch}.apk ; ls -l ; echo y | apk add --allow-untrusted msodbcsql18_${MSODBC_VERSION}_${mssql_arch}.apk mssql-tools18_${MSSQL_VERSION}_${mssql_arch}.apk ; else echo >&2 "Detected non x86_64 or ARM64 build variant, skipping MSSQL installation" ; fi; \
     if [ $influx2 = "true" ] ; then curl -sSL https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX2_VERSION}-linux-${influx_arch}.tar.gz | tar xvfz - --strip=1 -C /usr/src/ ; chmod +x /usr/src/influx ; mv /usr/src/influx /usr/sbin/ ; else echo >&2 "Unable to build Influx 2 on this system" ; fi ; \
-    clone_git_repo https://github.com/aws/aws-cli "${AWS_CLI_VERSION}" && \
-    python3 setup.py install --prefix=/usr && \
+    pip3 install --break-system-packages awscli==${AWS_CLI_VERSION} && \
     clone_git_repo https://github.com/influxdata/influxdb "${INFLUX_VERSION}" && \
     go build -o /usr/sbin/influxd ./cmd/influxd && \
     strip /usr/sbin/influxd && \


### PR DESCRIPTION
In this PR,

* Update AWS CLi to `1.31.5`
* Use pip3 to install awscli