### PR TITLE
[Docs] Updated `DEFAULT_CREATE_LATEST_SYMLINK` description format

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ If `DEFAULT_BACKUP_LOCTION` = `FILESYSTEM` then the following options are used:
 
 | Variable                             | Description                                                                                           | Default                               |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `DEFAULT_CREATE_LATEST_SYMLINK`      | Create a symbolic link pointing to last backup in this format: `latest-(DB_TYPE)-(DB_NAME)-(DB_HOST)` | `TRUE`                                |
+| `DEFAULT_CREATE_LATEST_SYMLINK`      | Create a symbolic link pointing to last backup in this format: `latest-(DB_TYPE)_(DB_NAME)_(DB_HOST)` | `TRUE`                                |
 | `DEFAULT_FILESYSTEM_PATH`            | Directory where the database dumps are kept.                                                          | `/backup`                             |
 | `DEFAULT_FILESYSTEM_PATH_PERMISSION` | Permissions to apply to backup directory                                                              | `700`                                 |
 | `DEFAULT_FILESYSTEM_ARCHIVE_PATH`    | Optional Directory where the database dumps archives are kept                                         | `${DEFAULT_FILESYSTEM_PATH}/archive/` |


### PR DESCRIPTION
According to the code, the format for `DEFAULT_CREATE_LATEST_SYMLINK` contains underscores between type, name and host (not dashes)

https://github.com/tiredofit/docker-db-backup/blob/a5b15b441246da0dea563fd4b150621fc7e358e7/install/assets/functions/10-db-backup#L1645